### PR TITLE
feat: `SqliteParameters.AddLiteral()`

### DIFF
--- a/sandbox/Benchmark/Benchmarks.cs
+++ b/sandbox/Benchmark/Benchmarks.cs
@@ -82,8 +82,8 @@ public class Benchmarks
         conn.ExecuteNonQuery("CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT);");
 
         using var cmd = conn.CreateCommand("INSERT INTO t(val) VALUES ($foo), ($bar);");
-        cmd.Parameters.Add("$foo"u8, "foo"u8);
-        cmd.Parameters.Add("$bar"u8, "bar"u8);
+        cmd.Parameters.AddLiteral("$foo"u8, "foo"u8);
+        cmd.Parameters.AddLiteral("$bar"u8, "bar"u8);
         cmd.ExecuteNonQuery();
 
         using var reader = conn.ExecuteReader("SELECT * FROM t;");

--- a/src/CsSqlite.Native/Constants.cs
+++ b/src/CsSqlite.Native/Constants.cs
@@ -1,3 +1,5 @@
+using System.Runtime.InteropServices;
+
 namespace CsSqlite;
 
 public static class Constants
@@ -12,4 +14,7 @@ public static class Constants
     public const int SQLITE_TEXT = 3;
     public const int SQLITE_BLOB = 4;
     public const int SQLITE_NULL = 5;
+
+    public unsafe static readonly delegate* unmanaged[Cdecl]<void*, void> SQLITE_STATIC = (delegate* unmanaged[Cdecl]<void*, void>)0;
+    public unsafe static readonly delegate* unmanaged[Cdecl]<void*, void> SQLITE_TRANSIENT = (delegate* unmanaged[Cdecl]<void*, void>)-1;
 }


### PR DESCRIPTION
To address issue #7, we've added `AddLiteral()` for text parameters and changed the behavior of existing `Add()` functions.

- For safety reasons, we've changed `Add()`/`AddBytes()` to always use `SQLITE_TRANSIENT`.
- As an optimization for when the text is a constant, we've added `AddLiteral()` that uses SQLITE_STATIC. The behavior is undefined if a non-literal value is passed to this function. (In .NET 8 and later, `[ConstantExpected]` is added to the parameter.)